### PR TITLE
remove `removeDimensions` optimization

### DIFF
--- a/optimize.js
+++ b/optimize.js
@@ -2,7 +2,6 @@ function svgOptions() {
   return {
     plugins: [
       {removeTitle: true},
-      {removeDimensions: true},
       {removeViewBox: false},
     ],
   };

--- a/test/optimize.test.js
+++ b/test/optimize.test.js
@@ -6,8 +6,6 @@ describe('optimize()', () => {
   describe('svg', () => {
     it('removes all useless attributes', async () => {
       const content = await optimize(getFixture('basic'));
-      expect(content).not.toMatch(/width/);
-      expect(content).not.toMatch(/height/);
       expect(content).not.toMatch(/title/);
     });
   });


### PR DESCRIPTION
We've encountered issues with that when an svg is used as a [background pattern in a canvas](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createPattern).

The `naturalWidth` and `naturalHeight` seem to [to be set to intrinsic default values](https://www.w3.org/TR/css-sizing-3/#intrinsic-sizes) instead to fixed values as we'd need it. 
 
[mediawiki seems to deem that option as unsafe](https://www.mediawiki.org/wiki/Manual:Coding_conventions/SVG#Automated_optimisation_.28SVGO.29), too.